### PR TITLE
New feature/Bug fix - task execution tolerance parameter added

### DIFF
--- a/classes/CronJobsForms.php
+++ b/classes/CronJobsForms.php
@@ -201,6 +201,14 @@ class CronJobsForms
                 'id'    => 'id', 'name' => 'name',
             ],
         ];
+		$form[0]['form']['input'][] = [
+                    'type'    => 'text',
+                    'name'    => 'tolerance',
+                    'label'   => static::getModule()->l('Execution tolerance', 'CronJobsForms'),
+                    'desc'    => static::getModule()->l('Time tolerance for executing this task in seconds.', 'CronJobsForms'),
+                    'placeholder'   => '10',
+					'suffix'  => static::getModule()->l('seconds'),
+        ];
 
         return $form;
     }
@@ -305,16 +313,17 @@ class CronJobsForms
     public static function getTasksList()
     {
         return [
-            'description' => ['title' => static::getModule()->l('Task description', 'CronJobsForms'), 'type' => 'text', 'orderby' => false],
-            'task'        => ['title' => static::getModule()->l('Target link', 'CronJobsForms'),      'type' => 'text', 'orderby' => false],
-            'minute'      => ['title' => static::getModule()->l('Minute', 'CronJobsForms'),           'type' => 'text', 'orderby' => false],
-            'hour'        => ['title' => static::getModule()->l('Hour', 'CronJobsForms'),             'type' => 'text', 'orderby' => false],
-            'day'         => ['title' => static::getModule()->l('Day', 'CronJobsForms'),              'type' => 'text', 'orderby' => false],
-            'month'       => ['title' => static::getModule()->l('Month', 'CronJobsForms'),            'type' => 'text', 'orderby' => false],
-            'day_of_week' => ['title' => static::getModule()->l('Day of week', 'CronJobsForms'),      'type' => 'text', 'orderby' => false],
-            'updated_at'  => ['title' => static::getModule()->l('Last execution', 'CronJobsForms'),   'type' => 'text', 'orderby' => false],
-            'one_shot'    => ['title' => static::getModule()->l('One shot', 'CronJobsForms'),         'active' => 'oneshot', 'type' => 'bool', 'align' => 'center'],
-            'active'      => ['title' => static::getModule()->l('Active', 'CronJobsForms'),           'active' => 'status', 'type' => 'bool', 'align' => 'center', 'orderby' => false],
+            'description' => ['title' => static::getModule()->l('Task description', 'CronJobsForms'),    'type' => 'text', 'orderby' => false],
+            'task'        => ['title' => static::getModule()->l('Target link', 'CronJobsForms'),         'type' => 'text', 'orderby' => false],
+            'minute'      => ['title' => static::getModule()->l('Minute', 'CronJobsForms'),              'type' => 'text', 'orderby' => false],
+            'hour'        => ['title' => static::getModule()->l('Hour', 'CronJobsForms'),                'type' => 'text', 'orderby' => false],
+            'day'         => ['title' => static::getModule()->l('Day', 'CronJobsForms'),                 'type' => 'text', 'orderby' => false],
+            'month'       => ['title' => static::getModule()->l('Month', 'CronJobsForms'),               'type' => 'text', 'orderby' => false],
+            'day_of_week' => ['title' => static::getModule()->l('Day of week', 'CronJobsForms'),         'type' => 'text', 'orderby' => false],
+            'tolerance'   => ['title' => static::getModule()->l('Execution tolerance', 'CronJobsForms'), 'type' => 'text', 'orderby' => false],
+            'updated_at'  => ['title' => static::getModule()->l('Last execution', 'CronJobsForms'),      'type' => 'text', 'orderby' => false],
+            'one_shot'    => ['title' => static::getModule()->l('One shot', 'CronJobsForms'),            'active' => 'oneshot', 'type' => 'bool', 'align' => 'center'],
+            'active'      => ['title' => static::getModule()->l('Active', 'CronJobsForms'),              'active' => 'status', 'type' => 'bool', 'align' => 'center', 'orderby' => false],
         ];
     }
 
@@ -331,6 +340,7 @@ class CronJobsForms
             'day'         => (int) Tools::getValue('day', -1),
             'month'       => (int) Tools::getValue('month', -1),
             'day_of_week' => (int) Tools::getValue('day_of_week', -1),
+            'tolerance'   => (int) Tools::getValue('tolerance', 10),
         ];
     }
 
@@ -373,6 +383,7 @@ class CronJobsForms
             'day'         => (int) Tools::getValue('day', $cron['day']),
             'month'       => (int) Tools::getValue('month', $cron['month']),
             'day_of_week' => (int) Tools::getValue('day_of_week', $cron['day_of_week']),
+            'tolerance'   => (int) Tools::getValue('tolerance', $cron['tolerance']),
         ];
     }
 
@@ -423,6 +434,7 @@ class CronJobsForms
             $cron['day'] = ($cron['day'] == -1) ? static::getModule()->l('Every day', 'CronJobsForms') : (int) $cron['day'];
             $cron['month'] = ($cron['month'] == -1) ? static::getModule()->l('Every month', 'CronJobsForms') : static::getModule()->l(date('F', mktime(0, 0, 0, (int) $cron['month'], 1)));
             $cron['day_of_week'] = ($cron['day_of_week'] == -1) ? static::getModule()->l('Every day of the week', 'CronJobsForms') : static::getModule()->l(date('l', mktime(0, 0, 0, 0, (int) $cron['day_of_week'] + 3)));
+            $cron['tolerance'] = ($cron['tolerance'] == 0) ? static::getModule()->l('No tolerance', 'CronJobsForms') : (int) $cron['tolerance'] . ' seconds';
             $cron['updated_at'] = ($cron['updated_at'] == 0) ? static::getModule()->l('Never', 'CronJobsForms') : date('Y-m-d H:i:s', strtotime($cron['updated_at']));
             $cron['one_shot'] = (bool) $cron['one_shot'];
             $cron['active'] = (bool) $cron['active'];

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -192,7 +192,7 @@ class CronJobscronModuleFrontController extends ModuleFrontController
      */
     protected function getCronTolerance($cron)
     {
-        return (int) $cron['tolernace'] == -1 ? 0 : $cron['tolerance'];
+        return (int) $cron['tolerance'] == -1 ? 0 : $cron['tolerance'];
     }
     
     /**

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -252,7 +252,8 @@ class CronJobscronModuleFrontController extends ModuleFrontController
                     Db::getInstance()->update(
                         \Cronjobs::TABLE,
                         [
-                            'updated_at' => ['type' => 'sql', 'value' => 'IF (`one_shot` = TRUE, FALSE, `active`)'],
+                            'updated_at' => ['type' => 'sql', 'value' => 'NOW()'],
+                            'active'     => ['type' => 'sql', 'value' => 'IF(`one_shot` = TRUE, FALSE, `active`)'],
                         ],
                         '`id_cronjob` = '.(int) $cron['id_cronjob']
                     );

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -148,9 +148,82 @@ class CronJobscronModuleFrontController extends ModuleFrontController
 
         $day = date('Y').'-'.str_pad($month, 2, '0', STR_PAD_LEFT).'-'.str_pad($day, 2, '0', STR_PAD_LEFT);
         $execution = $dayOfWeek.' '.$day.' '.str_pad($hour, 2, '0', STR_PAD_LEFT).':'.str_pad($minute, 2, '0', STR_PAD_LEFT);
-        $now = date('D Y-m-d H:i');
+        
+        $tolerance = $this->getCronTolerance($cron);
+        
+        if ($tolerance > 0)
+        {
+            $seconds = $this->dateTimeDiffToSeconds(
+                new DateTime($execution)
+                );
+        
+            if (abs($seconds) <= $tolerance) {
+                return !(bool) $this->wasExecutedInToleranceWhileAgo($cron);
+            }
+            else {
+                return false;
+            }
+        }
+        else
+        {
+            $now = date('D Y-m-d H:i');
+            return !(bool) strcmp($now, $execution);
+        }
+    }
+    
+    /**
+     * @param DateTime $dateTime
+     * @param optional DateTime $reference
+     * @return int seconds
+     */
+    protected function dateTimeDiffToSeconds($dateTime, $reference = null)
+    {
+        if ($reference == null)
+            $reference = new DateTime('now');
+        
+        $interval = $dateTime->getTimestamp() - $reference->getTimestamp();
 
-        return !(bool) strcmp($now, $execution);
+        return (int) $interval;
+    }
+    
+    /**
+     * @param array $cron
+     * @return int seconds
+     */
+    protected function getCronTolerance($cron)
+    {
+        return (int) $cron['tolernace'] == -1 ? 0 : $cron['tolerance'];
+    }
+    
+    /**
+     * @param array $cron
+     * @return DateTime
+     */
+    protected function getLastExecutionDate($cron)
+    {
+        return new DateTime($cron['updated_at']);
+    }
+    
+    /**
+     * @param array $cron
+     * @return bool
+     */
+    protected function wasExecutedInToleranceWhileAgo($cron)
+    {
+        $tolerance = $this->getCronTolerance($cron);
+        $now = new DateTime('now');
+        
+        if (abs($this->dateTimeDiffToSeconds(
+                $this->getLastExecutionDate($cron),
+                $now->sub(new DateInterval('PT' . $tolerance . 'S'))
+                )
+				)
+                >=
+                $tolerance
+            )
+            return false;
+        
+        return true;
     }
 
     /**

--- a/cronjobs.php
+++ b/cronjobs.php
@@ -56,7 +56,7 @@ class CronJobs extends Module
     {
         $this->name = 'cronjobs';
         $this->tab = 'administration';
-        $this->version = '2.1.3';
+        $this->version = '2.1.4';
 
         $this->controllers = ['cron'];
 
@@ -178,6 +178,7 @@ class CronJobs extends Module
                     'day'           => static::EACH,
                     'month'         => static::EACH,
                     'day_of_week'   => static::EACH,
+					'tolerance'     => '0',
                     'updated_at'    => null,
                     'one_shot'      => true,
                     'active'        => true,
@@ -192,6 +193,7 @@ class CronJobs extends Module
             $day = (int) $execution['day'];
             $month = (int) $execution['month'];
             $dayOfWeek = (int) $execution['day_of_week'];
+            $tolerance = (int) $execution['tolerance'];
 
             $isFrequencyValid = (($minute >= -1) && ($minute < 60) && $isFrequencyValid);
             $isFrequencyValid = (($hour >= -1) && ($hour < 24) && $isFrequencyValid);
@@ -210,6 +212,7 @@ class CronJobs extends Module
                         'day'           => $day,
                         'month'         => $month,
                         'day_of_week'   => $dayOfWeek,
+						'tolerance'     => $tolerance,
                         'updated_at'    => null,
                         'one_shot'      => true,
                         'active'        => true,
@@ -264,6 +267,7 @@ class CronJobs extends Module
             `day`           INT(11)    DEFAULT \'-1\',
             `month`         INT(11)    DEFAULT \'-1\',
             `day_of_week`   INT(11)    DEFAULT \'-1\',
+            `tolerance`     INT(11)    DEFAULT \'0\',
             `updated_at`    DATETIME   DEFAULT NULL,
             `one_shot`      TINYINT(1) NOT NULL DEFAULT 0,
             `active`        TINYINT(1) DEFAULT FALSE,
@@ -343,6 +347,7 @@ class CronJobs extends Module
                     'day'           => $frequency['day'],
                     'month'         => $frequency['month'],
                     'day_of_week'   => $frequency['day_of_week'],
+                    'tolerance'     => 0,
                     'active'        => true,
                     'id_shop'       => $idShop,
                     'id_shop_group' => $idShopGroup,
@@ -489,6 +494,7 @@ class CronJobs extends Module
             $day = (int) Tools::getValue('day');
             $month = (int) Tools::getValue('month');
             $dayOfWeek = (int) Tools::getValue('day_of_week');
+            $tolerance = (int) Tools::getValue('tolerance');
 
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
                 (new DbQuery())
@@ -500,6 +506,7 @@ class CronJobs extends Module
                     ->where('`day` = \''.pSQL($day).'\'')
                     ->where('`month` = \''.pSQL($month).'\'')
                     ->where('`day_of_week` = \''.pSQL($dayOfWeek).'\'')
+                    ->where('`tolerance` = \''.pSQL($tolerance).'\'')
             );
 
             if (!$result) {
@@ -515,6 +522,7 @@ class CronJobs extends Module
                         'day'           => (int) $day,
                         'month'         => (int) $month,
                         'day_of_week'   => (int) $dayOfWeek,
+                        'tolerance'     => (int) $tolerance,
                         'updated_at'    => ['type' => 'sql', 'value' => 'NOW()'],
                         'active'        => 1,
                         'id_shop'       => (int) $idShop,
@@ -544,15 +552,17 @@ class CronJobs extends Module
             (Tools::isSubmit('hour')) &&
             (Tools::isSubmit('day')) &&
             (Tools::isSubmit('month')) &&
-            (Tools::isSubmit('day_of_week'))
+            (Tools::isSubmit('day_of_week')) &&
+            (Tools::isSubmit('tolerance'))
         ) {
             $minute = Tools::getValue('minute');
             $hour = Tools::getValue('hour');
             $day = Tools::getValue('day');
             $month = Tools::getValue('month');
             $dayOfWeek = Tools::getValue('day_of_week');
+            $tolerance = Tools::getValue('tolerance');
 
-            return $this->isFrequencyValid($minute, $hour, $day, $month, $dayOfWeek);
+            return $this->isFrequencyValid($minute, $hour, $day, $month, $dayOfWeek, $tolerance);
         }
 
         return false;
@@ -583,7 +593,7 @@ class CronJobs extends Module
      *
      * @return bool
      */
-    protected function isFrequencyValid($minute, $hour, $day, $month, $dayOfWeek)
+    protected function isFrequencyValid($minute, $hour, $day, $month, $dayOfWeek, $tolerance)
     {
         $success = true;
 
@@ -601,6 +611,9 @@ class CronJobs extends Module
         }
         if (!(($dayOfWeek >= -1) && ($dayOfWeek < 7))) {
             $success &= $this->setErrorMessage('The value you chose for the day of the week is not valid.');
+        }
+		if (!(($tolerance >= -1) && ($tolerance < 0))) {
+            $success &= $this->setErrorMessage('The value you chose for the execution tolerance is not valid.');
         }
 
         return $success;
@@ -628,6 +641,7 @@ class CronJobs extends Module
                 'day'         => (int) Tools::getValue('day'),
                 'month'       => (int) Tools::getValue('month'),
                 'day_of_week' => (int) Tools::getValue('day_of_week'),
+                'tolerance'   => (int) Tools::getValue('tolerance'),
             ],
             '`id_cronjob` = '.(int) Tools::getValue('id_cronjob')
         );

--- a/upgrade/upgrade-2.1.4.php
+++ b/upgrade/upgrade-2.1.4.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2018 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2017-2018 thirty bees
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_1_4()
+{
+    Db::getInstance()->execute('ALTER TABLE `cronjobs` ADD `tolerance` INTEGER DEFAULT \'0\' AFTER `day_of_week`');
+
+    return true;
+}


### PR DESCRIPTION
Added execution tolerance parameter to each cron task.
On some shared webhosts are web crons which runs at an approximate time.
One of my webhosts allow to run cron at max every 10 minutes. A lot of my cron tasks do not get executed due to inacurate cron execution - approximatelly from 7 to 15 minutes at this webhost.

This verion allows you specify execution tolerance time to each task. So when time get closer to desired execution, it fires task execution in advance or lately, once per desired tolerance window.